### PR TITLE
Serializers and views

### DIFF
--- a/hackoregon_transportation_systems/toad/serializers.py
+++ b/hackoregon_transportation_systems/toad/serializers.py
@@ -7,7 +7,7 @@ class BusAllStopsSerializer(serializers.GeoFeatureModelSerializer):
     class Meta:
         model = BusAllStops
         fields = "__all__"
-        geo_field = "geom_4326"
+        geo_field = "geom_point_4326"
         id = "id"
 
 
@@ -15,5 +15,5 @@ class BusPassengerStopsSerializer(serializers.GeoFeatureModelSerializer):
     class Meta:
         model = BusPassengerStops
         fields = "__all__"
-        geo_field = "geom_4326"
+        geo_field = "geom_point_4326"
         id = "id"

--- a/hackoregon_transportation_systems/toad/serializers.py
+++ b/hackoregon_transportation_systems/toad/serializers.py
@@ -1,1 +1,19 @@
 from rest_framework import serializers
+from rest_framework_gis import serializers
+from toad.models import BusAllStops, BusPassengerStops
+
+
+class BusAllStopsSerializer(serializers.GeoFeatureModelSerializer):
+    class Meta:
+        model = BusAllStops
+        fields = "__all__"
+        geo_field = "geom_4326"
+        id = "id"
+
+
+class BusPassengerStopsSerializer(serializers.GeoFeatureModelSerializer):
+    class Meta:
+        model = BusPassengerStops
+        fields = "__all__"
+        geo_field = "geom_4326"
+        id = "id"

--- a/hackoregon_transportation_systems/toad/urls.py
+++ b/hackoregon_transportation_systems/toad/urls.py
@@ -1,16 +1,9 @@
-from django.conf.urls import url, include
+from django.conf.urls import include, url
 from rest_framework.routers import DefaultRouter
-from rest_framework.schemas import get_schema_view
-from rest_framework_swagger.views import get_swagger_view
+from toad import views
 
 router = DefaultRouter()
+router.register(r"bus-all-stops", views.BusAllStopsViewSet)
+router.register(r"bus-passenger-stops", views.BusPassengerStopsViewSet)
 
-
-#schema view
-schema_view = get_swagger_view(title='Transportation Systems 2019 API')
-
-urlpatterns = [
-    url(r'^schema/', schema_view),
-    url
-    url(r'^toad/', include(router.urls)),
-]
+urlpatterns = [url(r"^/", include(router.urls))]

--- a/hackoregon_transportation_systems/toad/urls.py
+++ b/hackoregon_transportation_systems/toad/urls.py
@@ -6,4 +6,4 @@ router = DefaultRouter()
 router.register(r"bus-all-stops", views.BusAllStopsViewSet)
 router.register(r"bus-passenger-stops", views.BusPassengerStopsViewSet)
 
-urlpatterns = [url(r"^/", include(router.urls))]
+urlpatterns = [url(r"^", include(router.urls))]

--- a/hackoregon_transportation_systems/toad/views.py
+++ b/hackoregon_transportation_systems/toad/views.py
@@ -1,4 +1,26 @@
-from django.http import HttpResponse, JsonResponse
-from rest_framework.decorators import api_view, detail_route
-from rest_framework.renderers import JSONRenderer
-from rest_framework.parsers import JSONParser
+# from django.http import HttpResponse, JsonResponse
+from rest_framework import viewsets
+
+# from rest_framework.decorators import api_view, detail_route
+# from rest_framework.parsers import JSONParser
+# from rest_framework.renderers import JSONRenderer
+from toad.models import BusAllStops, BusPassengerStops
+from toad.serializers import BusAllStopsSerializer, BusPassengerStopsSerializer
+
+
+class BusAllStopsViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    This viewset will provide a list of all times a bus stops (scheduled or not).
+    """
+
+    queryset = BusAllStops.objects.all()
+    serializer_class = BusAllStopsSerializer
+
+
+class BusPassengerStopsViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    This viewset will provide a list of scheduled stops along a Trimet line.
+    """
+
+    queryset = BusPassengerStops.objects.all()
+    serializer_class = BusPassengerStopsSerializer

--- a/local_settings/settings.py
+++ b/local_settings/settings.py
@@ -6,39 +6,39 @@ import os
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = (os.environ.get('DEBUG').lower() == "true")
+DEBUG = os.environ.get("DEBUG").lower() == "true"
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'django.contrib.gis',
-    'corsheaders',
-    'django_filters',
-    'rest_framework',
-    'rest_framework_gis',
-    'rest_framework_swagger',
-    'hackoregon_transportation_systems.toad'
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "django.contrib.gis",
+    "corsheaders",
+    "django_filters",
+    "rest_framework",
+    "rest_framework_gis",
+    "rest_framework_swagger",
+    "toad",
 ]
 
-DATABASE_ROUTERS = ['backend.router.ModelDatabaseRouter',]
+DATABASE_ROUTERS = ["backend.router.ModelDatabaseRouter"]
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.contrib.gis.db.backends.postgis',
-        'PASSWORD': os.environ.get('POSTGRES_PASSWORD'),
-        'NAME': os.environ.get('POSTGRES_NAME'),
-        'USER': os.environ.get('POSTGRES_USER'),
-        'HOST': os.environ.get('POSTGRES_HOST'),
-        'PORT': os.environ.get('POSTGRES_PORT')
+    "default": {
+        "ENGINE": "django.contrib.gis.db.backends.postgis",
+        "PASSWORD": os.environ.get("POSTGRES_PASSWORD"),
+        "NAME": os.environ.get("POSTGRES_NAME"),
+        "USER": os.environ.get("POSTGRES_USER"),
+        "HOST": os.environ.get("POSTGRES_HOST"),
+        "PORT": os.environ.get("POSTGRES_PORT"),
     }
 }
 
-STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
-STATIC_URL = '/hackoregon_transportation_systems/static/'
+STATIC_URL = "/hackoregon_transportation_systems/static/"

--- a/local_settings/urls.py
+++ b/local_settings/urls.py
@@ -1,0 +1,16 @@
+from django.conf.urls import url, include
+from rest_framework.routers import DefaultRouter
+from rest_framework_swagger.views import get_swagger_view
+
+router = DefaultRouter()
+
+schema_view = get_swagger_view(title="Hack Oregon Transportation Systems 2019 API")
+
+
+urlpatterns = [
+    url(r"^transportation-systems/schema/", schema_view),
+    url(
+        r"^transportation-systems/toad/",
+        include("hackoregon_transportation_systems.toad.urls"),
+    ),
+]


### PR DESCRIPTION
This gets some basic working views on the API for the `bus-all-stops` and `bus-passenger-stops` tables. It seems I also forgot that I auto format with `black` on save ... so all the `'` were switched to `"`. Not sure if anyone else has strong feelings about that. I believe this should close #4, however it seems that template is still a WIP. But I think we're up to date as of now.