### PR TITLE
disturbance stops view creation (issue #22)

### DIFF
--- a/views_sql/disturbance_stops.sql
+++ b/views_sql/disturbance_stops.sql
@@ -1,0 +1,8 @@
+SELECT bus_all_stops.opd_date, DATE_PART('dow', bus_all_stops.opd_date) AS day_of_week,
+  bus_all_stops.act_arr_time, bus_all_stops.act_dep_time, 
+  bus_all_stops.act_dep_time - bus_all_stops.act_arr_time AS duration,
+  bus_trips.line_id, geom_point_4326
+FROM bus_all_stops
+LEFT JOIN bus_trips ON bus_trips.event_no_trip = bus_all_stops.event_no_trip
+WHERE stop_type = 3
+LIMIT 100;

--- a/views_sql/disturbance_stops.sql
+++ b/views_sql/disturbance_stops.sql
@@ -1,5 +1,9 @@
-DROP MATERIALIZED VIEW IF EXISTS public.disturbance_stops CASCADE;
-CREATE MATERIALIZED VIEW public.disturbance_stops
+DROP INDEX IF EXISTS bus_trips_event_no_trip_idx;
+CREATE INDEX bus_trips_event_no_trip_idx ON bus_trips (event_no_trip);
+DROP INDEX IF EXISTS bus_all_stops_event_no_trip_idx;
+CREATE INDEX bus_all_stops_event_no_trip_idx ON bus_all_stops (event_no_trip);
+DROP MATERIALIZED VIEW IF EXISTS disturbance_stops CASCADE;
+CREATE MATERIALIZED VIEW disturbance_stops
 AS
 SELECT bus_all_stops.opd_date, date_part('dow', bus_all_stops.opd_date) AS day_of_week,
   bus_all_stops.act_arr_time, bus_all_stops.act_dep_time,
@@ -16,5 +20,5 @@ WHERE stop_type = 3
 
 WITH DATA;
 
-ALTER TABLE public.disturbance_stops
+ALTER TABLE disturbance_stops
     OWNER TO transportation2019;

--- a/views_sql/disturbance_stops.sql
+++ b/views_sql/disturbance_stops.sql
@@ -1,8 +1,20 @@
-SELECT bus_all_stops.opd_date, DATE_PART('dow', bus_all_stops.opd_date) AS day_of_week,
-  bus_all_stops.act_arr_time, bus_all_stops.act_dep_time, 
+DROP MATERIALIZED VIEW IF EXISTS public.disturbance_stops CASCADE;
+CREATE MATERIALIZED VIEW public.disturbance_stops
+AS
+SELECT bus_all_stops.opd_date, date_part('dow', bus_all_stops.opd_date) AS day_of_week,
+  bus_all_stops.act_arr_time, bus_all_stops.act_dep_time,
+  0.25 * trunc(4 * date_part('hour', bus_all_stops.act_arr_time) +
+    date_part('minute', bus_all_stops.act_arr_time) / 15) AS start_quarter_hour,
+  0.25 * trunc(4 * date_part('hour', bus_all_stops.act_dep_time) +
+    date_part('minute', bus_all_stops.act_dep_time) / 15) AS end_quarter_hour,
   bus_all_stops.act_dep_time - bus_all_stops.act_arr_time AS duration,
-  bus_trips.line_id, geom_point_4326
+  bus_trips.line_id, bus_trips.pattern_direction,
+  ST_X(geom_point_4326) AS longitude, ST_Y(geom_point_4326) AS latitude, geom_point_4326
 FROM bus_all_stops
-LEFT JOIN bus_trips ON bus_trips.event_no_trip = bus_all_stops.event_no_trip
+INNER JOIN bus_trips ON bus_trips.event_no_trip = bus_all_stops.event_no_trip
 WHERE stop_type = 3
-LIMIT 100;
+
+WITH DATA;
+
+ALTER TABLE public.disturbance_stops
+    OWNER TO transportation2019;


### PR DESCRIPTION
The code to create two indexes and the materialized view is done. I've tested it on the full TOAD database locally; once the indexes are built, it only takes about two minutes to refresh the view.

I'm uploading the resulting dataset as a CSV file to S3 so the data scientists can look at it and see if things look good. It's about 1 GB - I'll post the link once it's fully updated.

Once we know we have the right columns for the story cards, I'll run the indexing / view creation on the RDS instance and take another backup file.

P.S.: the longitude and latitude values are the same as what's encoded in `geom_point_4326`. I don't know what GIS capabilities the data scientists and front end developers have, so there's redundant information there.